### PR TITLE
add an example to toggle the active view's opaqueness

### DIFF
--- a/examples/wayfire-toggle-active-alpha/Cargo.toml
+++ b/examples/wayfire-toggle-active-alpha/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "wayfire-toggle-active-alpha"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+signal-hook = "0.3.17"
+tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
+wayfire-rs = "0.2.2"

--- a/examples/wayfire-toggle-active-alpha/README.md
+++ b/examples/wayfire-toggle-active-alpha/README.md
@@ -1,0 +1,27 @@
+# wayfire-toggle-active-alpha
+
+This little program is used to toggle the opacity (alpha value) of windows (views) in Wayfire
+
+After running it, trigger the toggle by sending `SIGUSR1`, like this:
+```sh
+kill -n 10 $(pidof wayfire-toggle-active-alpha)
+```
+If this doesn't work, double check with `kill -l` that the signal number of `SIGUSR1` is 10
+
+## Use this for real
+To actually use this, run the following:
+```sh
+cargo build --release
+sudo mv target/release/wayfire-toggle-active-alpha /usr/local/bin
+rm -r target
+```
+
+Then modify your `wayfire.ini` by adding smth like the following:
+```ini
+[autostart]
+alpha_toggle = wayfire-toggle-active-alpha
+
+[command]
+binding_alpha_toggle = <alt> <shift> KEY_O
+command_alpha_toggle = kill -n 10 $(pidof wayfire-toggle-active-alpha)
+```

--- a/examples/wayfire-toggle-active-alpha/src/main.rs
+++ b/examples/wayfire-toggle-active-alpha/src/main.rs
@@ -1,0 +1,48 @@
+use std::{collections::HashMap, error::Error};
+
+use signal_hook::{consts::SIGUSR1, iterator::Signals};
+use wayfire_rs::ipc::WayfireSocket;
+
+/// This little program is used to toggle the opacity
+/// (alpha value) of windows (views) in Wayfire
+///
+/// After running it, trigger the toggle by sending SIGUSR1, like this:
+/// `kill -n 10 $(pidof wayfire-toggle-active-alpha)`
+/// If this doesn't work, double check with `kill -l` that SIGUSR1 is 10
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut socket = WayfireSocket::connect().await?;
+
+    let mut defaults: HashMap<i64, f64> = HashMap::new();
+
+    for _ in Signals::new([SIGUSR1])?.forever() {
+        let Ok(view) = socket.get_focused_view().await else {
+            continue;
+        };
+
+        let Ok(alpha) = socket.get_view_alpha(view.id).await.map(|v| v.alpha) else {
+            continue;
+        };
+
+        let default_alpha = match defaults.get(&view.id) {
+            Some(default) => *default,
+            None => {
+                defaults.insert(view.id, alpha);
+                alpha
+            }
+        };
+
+        let new_alpha = match default_alpha == alpha {
+            true => 1.,
+            false => default_alpha,
+        };
+
+        let Ok(_) = socket.set_view_alpha(view.id, new_alpha).await else {
+            eprintln!("Failed to toggle alpha");
+            continue;
+        };
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
As described in `examples/wayfire-toggle-active-alpha/README.md`, this example toggles the opaqueness of the currently focused view.
Maybe I'm just blind and theres an option to do this without such an extra script, but while looking at wayfire's wiki I was unable to find a option to do this.

Btw, this is a really nice library, thx for you effort :)