### PR TITLE
feat: add pending event queue

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
+    // Watch for geometry changed events
+    match socket
+        .watch(Some(vec!["view-geometry-changed".to_string()]))
+        .await
+    {
+        Ok(response) => print_json("watch", response).await?,
+        Err(e) => eprintln!("Failed to watch for events: {}", e),
+    }
+
     // Configure view
     match socket
         .configure_view(focused_view_id, 100, 100, 800, 600, Some(1))
@@ -130,6 +139,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     {
         Ok(response) => print_json("configure_view", response).await?,
         Err(e) => eprintln!("Failed to configure view: {}", e),
+    }
+
+    // Read the next event (should be the above configure view)
+    match socket.read_next_event().await {
+        Ok(event) => print_json("read_next_event", event).await?,
+        Err(e) => eprintln!("Failed to read next event: {}", e),
     }
 
     // Assign slot


### PR DESCRIPTION
I was writing an IPC script that was listening for `view-mapped` and `view-geometry-changed` events at the same time and realized that `socket.list_views()` would suddenly fail because it tried to read an event that was already queued on the socket instead of its response.
So this adds the pending event queue similar to how it is done in pywayfire.

I also added a test to the main file.